### PR TITLE
added gameplay changes

### DIFF
--- a/scenes/GameScene/Enemy/Projectile/bomb_explode.gd
+++ b/scenes/GameScene/Enemy/Projectile/bomb_explode.gd
@@ -3,7 +3,7 @@ extends ShapeCast2D
 @export var AP: AnimationPlayer
 @export var ASP: AudioStreamPlayer
 var _collision_max_radius = 47 #Radius times max scale
-var _max_damage = 50
+var _max_damage = 20
 
 func _ready():
 	AP.play("play")

--- a/scenes/GameScene/Enemy/bot_basic.tscn
+++ b/scenes/GameScene/Enemy/bot_basic.tscn
@@ -163,7 +163,7 @@ z_as_relative = false
 y_sort_enabled = true
 collision_layer = 2
 script = ExtResource("1_5766m")
-on_hit_damage = 0.15
+on_hit_damage = 5
 movement_type = 0
 AP = NodePath("SpriteSheet/AnimationPlayer")
 

--- a/scenes/GameScene/Enemy/bot_bomber.tscn
+++ b/scenes/GameScene/Enemy/bot_bomber.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="PackedScene" uid="uid://ccw87p5pjqyq" path="res://shaders/Sprite2DExtOutline.tscn" id="2_1ryq4"]
 
 [node name="BotBomber" instance=ExtResource("1_yglal")]
+on_hit_damage = 20.0
 spline_amplitude = 50.0
 spline_frequency = 1.0
 bomber = true
@@ -15,4 +16,7 @@ ShaderPattern = 1
 ShaderInside = false
 
 [node name="Health" parent="." index="2"]
-max_health = 12.0
+visible = true
+position = Vector2(2.08165e-12, 15)
+scale = Vector2(0.4, 0.4)
+max_health = 25.0

--- a/scenes/GameScene/Enemy/enemy.gd
+++ b/scenes/GameScene/Enemy/enemy.gd
@@ -88,7 +88,7 @@ func _process_animations():
 
 func _init_throw_timer():
 	_throw_timer = Timer.new()
-	_throw_timer.wait_time = randi_range(1, 4)
+	_throw_timer.wait_time = randi_range(1,1.5)
 	_throw_timer.autostart = true
 	_throw_timer.one_shot = true
 	_throw_timer.timeout.connect(_initbombthrow)
@@ -155,7 +155,7 @@ func _handle_hit_collision(col : KinematicCollision2D) -> void:
 	var collider : Node2D = col.get_collider()
 	if collider.is_in_group("Player"):
 		collider.health.add_or_subtract_health_by_value(-on_hit_damage)
-
+		health.add_or_subtract_health_by_value(-100)
 #endregion
 
 #region SFX

--- a/scenes/GameScene/MainGameScene.tscn
+++ b/scenes/GameScene/MainGameScene.tscn
@@ -19,8 +19,9 @@
 [ext_resource type="Script" path="res://scenes/GameScene/ParallaxLayer.gd" id="17_xitfh"]
 
 [sub_resource type="Curve" id="Curve_tktg1"]
-_data = [Vector2(0, 0), 0.0, 0.0, 0, 0, Vector2(1, 1), 0.0, 0.0, 0, 0]
-point_count = 2
+_data = [Vector2(0, 0), 0.0, 3.27091, 0, 0, Vector2(0.5, 0.7), 0.0, 0.0, 0, 0, Vector2(1, 1), 0.0, 0.0, 0, 0]
+point_count = 3
+metadata/_snap_enabled = true
 
 [sub_resource type="CurveTexture" id="CurveTexture_bredi"]
 curve = SubResource("Curve_tktg1")
@@ -49,11 +50,6 @@ SMid = NodePath("../../World2D/SpawnPoint/SRMid")
 SBtm = NodePath("../../World2D/SpawnPoint/SRBottom")
 SpawnNodeGroup = NodePath("../../World2D/SpawnPoint/Enemies")
 
-[node name="GameManager" type="Node" parent="Services"]
-script = ExtResource("1_klouh")
-win_scene = ExtResource("2_olcql")
-lose_scene = ExtResource("3_gbbo0")
-
 [node name="ScrollManager" type="Node" parent="Services"]
 script = ExtResource("6_2xlkp")
 total_game_time = 60.0
@@ -73,6 +69,11 @@ bus = &"Music"
 
 [node name="SFXPlayer" type="AudioStreamPlayer" parent="Services"]
 bus = &"SFX"
+
+[node name="GameManager" type="Node" parent="Services"]
+script = ExtResource("1_klouh")
+win_scene = ExtResource("2_olcql")
+lose_scene = ExtResource("3_gbbo0")
 
 [node name="World2D" type="Node2D" parent="."]
 z_as_relative = false
@@ -125,11 +126,12 @@ position = Vector2(75, -149)
 shape = SubResource("RectangleShape2D_fwqsb")
 
 [node name="ParallaxBackground" type="ParallaxBackground" parent="World2D"]
+scroll_offset = Vector2(10, 2.08165e-12)
 
 [node name="ParallaxLayer" type="ParallaxLayer" parent="World2D/ParallaxBackground"]
 motion_mirroring = Vector2(640, 0)
 script = ExtResource("17_xitfh")
-HSpeed = 0.0
+HSpeed = -200.0
 
 [node name="BG" type="Sprite2D" parent="World2D/ParallaxBackground/ParallaxLayer"]
 z_index = -1

--- a/scenes/GameScene/ParallaxLayer.gd
+++ b/scenes/GameScene/ParallaxLayer.gd
@@ -2,6 +2,7 @@ extends ParallaxLayer
 
 @export var HSpeed : float = -100
 var Multiplier: float = 1.0
+@onready var scroll_manager : ScrollManager= get_node("/root/MainGameScene/Services/ScrollManager")
 
 func _process(delta):
-	self.motion_offset.x += HSpeed * Multiplier * delta
+	self.motion_offset.x += HSpeed * scroll_manager.get_current_difficulty() * delta

--- a/scenes/Menus/OptionsMenu/Video/VideoOptionsMenuWithExtras.tscn
+++ b/scenes/Menus/OptionsMenu/Video/VideoOptionsMenuWithExtras.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=3 format=3 uid="uid://l7a6h2wm1hxe"]
 
-[ext_resource type="PackedScene" path="res://scenes/Menus/OptionsMenu/Video/VideoOptionsMenu.tscn" id="1_31w52"]
-[ext_resource type="PackedScene" path="res://addons/maaacks_game_template/base/scenes/Menus/OptionsMenu/OptionControl/ListOptionControl.tscn" id="2_0vjoi"]
+[ext_resource type="PackedScene" uid="uid://bodtmqyedikhj" path="res://scenes/Menus/OptionsMenu/Video/VideoOptionsMenu.tscn" id="1_31w52"]
+[ext_resource type="PackedScene" uid="uid://b6bl3n5mp3m1e" path="res://addons/maaacks_game_template/base/scenes/Menus/OptionsMenu/OptionControl/ListOptionControl.tscn" id="2_0vjoi"]
 
 [node name="Video" instance=ExtResource("1_31w52")]
 

--- a/scripts/managers/scroll_manager.gd
+++ b/scripts/managers/scroll_manager.gd
@@ -43,3 +43,7 @@ func get_raw_progress() -> float:
 # Modifying game to simply work on time
 func get_difficulty() -> float:
 	return current_game_time
+
+func get_current_difficulty() -> float:
+	var raw_progress = get_raw_progress()
+	return difficulty_curve_texture.get_curve().sample(raw_progress)


### PR DESCRIPTION
the overall goals are to provide a more natural difficulty curve for / onboarding players, and highlight key elements to the player by incentivizing dodging or "taking the hits" by bots but prioritize bombers

### changes

- added more gradual ramp up for the waves
- made all bots instant die on death to avoid collision bug with enemies
- max 3 bombers at a time possibly on screen
- added more health, and health bars to bombers
- added difficulty scaling speed on parallax layer
- reenabled checkpoint system, w healing (overtuned currently)
- added ability to win back in

### working on

- enemy variety (spine movement)
- adding a second mode (endless)
- possibly? boss
- fixing late game waves difficulty curve